### PR TITLE
Bring back tests for changes to transaction_database confirm methods

### DIFF
--- a/test/databases/transaction_database.cpp
+++ b/test/databases/transaction_database.cpp
@@ -544,293 +544,319 @@ BOOST_AUTO_TEST_CASE(transaction_database_with_cache__confirm2__single_transacti
     BOOST_REQUIRE(tx1_reloaded.transaction().outputs().front().metadata.spent(123, false));
 }
 
-////BOOST_AUTO_TEST_CASE(transaction_database_with_cache__confirm1__single_transaction_with_inputs_in_db__success)
-////{
-////    uint32_t version = 2345u;
-////    uint32_t locktime = 0xffffffff;
-////
-////    test::create(file_path);
-////    transaction_database instance(file_path, 1000, 50, 100);
-////    BOOST_REQUIRE(instance.create());
-////
-////    // tx1: coinbase transaction
-////    const chain::input::list tx1_inputs
-////    {
-////        { chain::point{ null_hash, chain::point::null_index }, {}, 0 }
-////    };
-////
-////    chain::output::list tx1_outputs
-////    {
-////        { 1200, {} },
-////        { 1200, {} },
-////    };
-////
-////    chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
-////    BOOST_REQUIRE(tx1.is_coinbase());
-////    const auto hash1 = tx1.hash();
-////    instance.store({tx1});
-////
-////    // tx2: spends coinbase, tx1/0 as input, dummy output
-////    chain::input::list tx2_inputs
-////    {
-////        { { hash1, 0 }, {}, 0 }
-////    };
-////
-////    chain::output::list tx2_outputs
-////    {
-////        { 1200, {} }
-////    };
-////
-////    // tx3: spends coinbase, tx1/1 as input, dummy output
-////    chain::input::list tx3_inputs
-////    {
-////        { { hash1, 1 }, {}, 0 }
-////    };
-////
-////    chain::output::list tx3_outputs
-////    {
-////        { 1200, {} }
-////    };
-////
-////    chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
-////    const auto hash2 = tx2.hash();
-////    instance.store(tx2, 1);
-////
-////    chain::transaction tx3(version, locktime, tx3_inputs, tx3_outputs);
-////    const auto hash3 = tx3.hash();
-////    instance.store(tx3, 1);
-////
-////    BOOST_REQUIRE(!instance.get(hash2).transaction().outputs().front().metadata.candidate_spend);
-////
-////    BOOST_REQUIRE_EQUAL(instance.get(hash1).height(), machine::rule_fork::unverified);
-////    BOOST_REQUIRE(!instance.get(hash1).transaction().outputs().front().metadata.spent(123, false));
-////
-////    // Setup end
-////
-////    const bool confirm1 = instance.confirm(instance.get(hash1).link(), 23, 56, 89);
-////    BOOST_REQUIRE(confirm1);
-////    const bool confirm2_3 = instance.confirm({tx2, tx3}, 123, 456);
-////    BOOST_REQUIRE(confirm2_3);
-////
-////    const auto tx2_reloaded = instance.get(hash2);
-////
-////    BOOST_REQUIRE_EQUAL(tx2_reloaded.height(), 123);
-////    BOOST_REQUIRE_EQUAL(tx2_reloaded.median_time_past(), 456);
-////    BOOST_REQUIRE_EQUAL(tx2_reloaded.position(), 0);
-////    BOOST_REQUIRE(!tx2_reloaded.candidate());
-////    BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spend);
-////
-////    const auto tx3_reloaded = instance.get(hash3);
-////
-////    BOOST_REQUIRE_EQUAL(tx3_reloaded.height(), 123);
-////    BOOST_REQUIRE_EQUAL(tx3_reloaded.median_time_past(), 456);
-////    BOOST_REQUIRE_EQUAL(tx3_reloaded.position(), 1);
-////    BOOST_REQUIRE(!tx3_reloaded.candidate());
-////    BOOST_REQUIRE(!tx3_reloaded.transaction().outputs().front().metadata.candidate_spend);
-////
-////    const auto tx1_reloaded = instance.get(hash1);
-////
-////    BOOST_REQUIRE_EQUAL(tx1_reloaded.height(), 23);
-////    BOOST_REQUIRE_EQUAL(tx1_reloaded.median_time_past(), 56);
-////    BOOST_REQUIRE_EQUAL(tx1_reloaded.position(), 89);
-////    BOOST_REQUIRE(!tx1_reloaded.candidate());
-////
-////    BOOST_REQUIRE_EQUAL(tx1_reloaded.transaction().outputs().front().metadata.confirmed_spend_height, 123);
-////    BOOST_REQUIRE(tx1_reloaded.transaction().outputs().front().metadata.spent(123, false));
-////}
+BOOST_AUTO_TEST_CASE(transaction_database_with_cache__confirm1__block_transactions_with_inputs_in_db__success)
+{
+   uint32_t version = 2345u;
+   uint32_t locktime = 0xffffffff;
+
+   test::create(file_path);
+   transaction_database instance(file_path, 1000, 50, 100);
+   BOOST_REQUIRE(instance.create());
+
+   // tx1: coinbase transaction
+   const chain::input::list tx1_inputs
+   {
+       { chain::point{ null_hash, chain::point::null_index }, {}, 0 }
+   };
+
+   chain::output::list tx1_outputs
+   {
+       { 1200, {} }
+   };
+
+   chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
+   BOOST_REQUIRE(tx1.is_coinbase());
+   const auto hash1 = tx1.hash();
+   instance.store({tx1});
+
+   // tx2: coinbase for block0
+   chain::input::list tx2_inputs
+   {
+       { chain::point{ null_hash, chain::point::null_index }, {}, 0 }
+   };
+
+   chain::output::list tx2_outputs
+   {
+       { 1201, {} }
+   };
+
+   // tx3: spends coinbase, tx1/1 as input, dummy output
+   chain::input::list tx3_inputs
+   {
+       { { hash1, 0 }, {}, 0 }
+   };
+
+   chain::output::list tx3_outputs
+   {
+       { 1200, {} }
+   };
+
+   chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
+   const auto hash2 = tx2.hash();
+   instance.store(tx2, 1);
+
+   chain::transaction tx3(version, locktime, tx3_inputs, tx3_outputs);
+   const auto hash3 = tx3.hash();
+   instance.store(tx3, 1);
+
+   BOOST_REQUIRE(!instance.get(hash2).transaction().outputs().front().metadata.candidate_spend);
+
+   BOOST_REQUIRE_EQUAL(instance.get(hash1).height(), machine::rule_fork::unverified);
+   BOOST_REQUIRE(!instance.get(hash1).transaction().outputs().front().metadata.spent(123, false));
+
+    static const auto settings = system::settings(system::config::settings::mainnet);
+    chain::block block0 = settings.genesis_block;
+    block0.set_transactions({ tx2, tx3 });
+
+    // Setup end
+
+   const bool confirm1 = instance.confirm(instance.get(hash1).link(), 23, 56, 89);
+   BOOST_REQUIRE(confirm1);
+
+   const auto tx1_reloaded = instance.get(hash1);
+
+   BOOST_REQUIRE_EQUAL(tx1_reloaded.height(), 23);
+   BOOST_REQUIRE_EQUAL(tx1_reloaded.median_time_past(), 56);
+   BOOST_REQUIRE_EQUAL(tx1_reloaded.position(), 89);
+   BOOST_REQUIRE(!tx1_reloaded.candidate());
+
+   const bool confirm2_3 = instance.confirm(block0, 123, 456);
+   BOOST_REQUIRE(confirm2_3);
+
+   const auto tx2_reloaded = instance.get(hash2);
+
+   BOOST_REQUIRE_EQUAL(tx2_reloaded.height(), 123);
+   BOOST_REQUIRE_EQUAL(tx2_reloaded.median_time_past(), 456);
+   BOOST_REQUIRE_EQUAL(tx2_reloaded.position(), 0);
+   BOOST_REQUIRE(!tx2_reloaded.candidate());
+   BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spend);
+
+   const auto tx3_reloaded = instance.get(hash3);
+
+   BOOST_REQUIRE_EQUAL(tx3_reloaded.height(), 123);
+   BOOST_REQUIRE_EQUAL(tx3_reloaded.median_time_past(), 456);
+   BOOST_REQUIRE_EQUAL(tx3_reloaded.position(), 1);
+   BOOST_REQUIRE(!tx3_reloaded.candidate());
+   BOOST_REQUIRE(!tx3_reloaded.transaction().outputs().front().metadata.candidate_spend);
+
+   const auto tx1_reloaded2 = instance.get(hash1);
+
+   BOOST_REQUIRE_EQUAL(tx1_reloaded2.height(), 23);
+   BOOST_REQUIRE_EQUAL(tx1_reloaded2.median_time_past(), 56);
+   BOOST_REQUIRE_EQUAL(tx1_reloaded2.position(), 89);
+   BOOST_REQUIRE(!tx1_reloaded2.candidate());
+
+   BOOST_REQUIRE_EQUAL(tx1_reloaded2.output(0).metadata.confirmed_spend_height, 123);
+   
+   BOOST_REQUIRE(tx1_reloaded2.transaction().outputs().front().metadata.spent(123, false));
+   BOOST_REQUIRE(tx1_reloaded2.is_spent(123, false));
+}
 
 // Unconfirm
 // ----------------------------------------------------------------------------
 
-////BOOST_AUTO_TEST_CASE(transaction_database__unconfirm__single_unconfirmed__success)
-////{
-////    uint32_t version = 2345u;
-////    uint32_t locktime = 0xffffffff;
-////
-////    test::create(file_path);
-////    transaction_database instance(file_path, 1000, 50, 0);
-////    BOOST_REQUIRE(instance.create());
-////
-////    // tx1: coinbase transaction
-////    const chain::input::list tx1_inputs
-////    {
-////        { chain::point{ null_hash, chain::point::null_index }, {}, 0 }
-////    };
-////
-////    chain::output::list tx1_outputs
-////    {
-////        { 1200, {} }
-////    };
-////
-////    chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
-////    BOOST_REQUIRE(tx1.is_coinbase());
-////    const auto hash1 = tx1.hash();
-////
-////    // tx2: spends coinbase, tx1 as input, dummy output
-////    chain::input::list tx2_inputs
-////    {
-////        { { hash1, 0 }, {}, 0 }
-////    };
-////
-////    chain::output::list tx2_outputs
-////    {
-////        { 1200, {} }
-////    };
-////
-////    chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
-////    const auto hash2 = tx2.hash();
-////
-////    instance.store({tx1, tx2});
-////
-////    // Setup end
-////
-////    const bool result = instance.unconfirm(instance.get(hash2).link());
-////    BOOST_REQUIRE(!result);
-////}
+BOOST_AUTO_TEST_CASE(transaction_database__unconfirm__block_with_unconfirmed_txs__success)
+{
+   uint32_t version = 2345u;
+   uint32_t locktime = 0xffffffff;
 
-////BOOST_AUTO_TEST_CASE(transaction_database__unconfirm__single_confirmed__success)
-////{
-////    uint32_t version = 2345u;
-////    uint32_t locktime = 0xffffffff;
-////
-////    test::create(file_path);
-////    transaction_database instance(file_path, 1000, 50, 0);
-////    BOOST_REQUIRE(instance.create());
-////
-////    // tx1: coinbase transaction
-////    const chain::input::list tx1_inputs
-////    {
-////        { chain::point{ null_hash, chain::point::null_index }, {}, 0 }
-////    };
-////
-////    chain::output::list tx1_outputs
-////    {
-////        { 1200, {} }
-////    };
-////
-////    chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
-////    BOOST_REQUIRE(tx1.is_coinbase());
-////    const auto hash1 = tx1.hash();
-////
-////    // tx2: spends coinbase, tx1 as input, dummy output
-////    chain::input::list tx2_inputs
-////    {
-////        { { hash1, 0 }, {}, 0 }
-////    };
-////
-////    chain::output::list tx2_outputs
-////    {
-////        { 1200, {} }
-////    };
-////
-////    chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
-////    const auto hash2 = tx2.hash();
-////
-////    instance.store({tx1, tx2});
-////    instance.confirm(instance.get(tx1.hash()).link(), 23, 56, 0);
-////    instance.confirm(instance.get(tx2.hash()).link(), 123, 156, 0);
-////
-////    BOOST_REQUIRE_EQUAL(instance.get(hash1).transaction().outputs().front().metadata.confirmed_spend_height, 123);
-////    BOOST_REQUIRE(instance.get(hash1).transaction().outputs().front().metadata.spent(123, false));
-////
-////    // Setup end
-////
-////    const bool result = instance.unconfirm(instance.get(hash2).link());
-////    BOOST_REQUIRE(result);
-////
-////    const auto tx2_reloaded = instance.get(hash2);
-////
-////    BOOST_REQUIRE_EQUAL(tx2_reloaded.height(), machine::rule_fork::unverified);
-////    BOOST_REQUIRE_EQUAL(tx2_reloaded.median_time_past(), 0u);
-////    BOOST_REQUIRE_EQUAL(tx2_reloaded.position(), transaction_result::unconfirmed);
-////    BOOST_REQUIRE(!tx2_reloaded.candidate());
-////    BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spend);
-////
-////    const auto tx1_reloaded = instance.get(hash1);
-////
-////    BOOST_REQUIRE_EQUAL(tx1_reloaded.height(), 23);
-////    BOOST_REQUIRE_EQUAL(tx1_reloaded.median_time_past(), 56);
-////    BOOST_REQUIRE_EQUAL(tx1_reloaded.position(), 0);
-////    BOOST_REQUIRE(!tx1_reloaded.candidate());
-////    BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.candidate_spend);
-////
-////
-////    BOOST_REQUIRE_EQUAL(tx1_reloaded.transaction().outputs().front().metadata.confirmed_spend_height,
-////        machine::rule_fork::unverified);
-////    BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.spent(123, false));
-////}
+   test::create(file_path);
+   transaction_database instance(file_path, 1000, 50, 0);
+   BOOST_REQUIRE(instance.create());
 
-////BOOST_AUTO_TEST_CASE(transaction_database_with_cache__unconfirm__single_confirmed__success)
-////{
-////    uint32_t version = 2345u;
-////    uint32_t locktime = 0xffffffff;
-////
-////    test::create(file_path);
-////    transaction_database instance(file_path, 1000, 50, 100);
-////    BOOST_REQUIRE(instance.create());
-////
-////    // tx1: coinbase transaction
-////    const chain::input::list tx1_inputs
-////    {
-////        { chain::point{ null_hash, chain::point::null_index }, {}, 0 }
-////    };
-////
-////    chain::output::list tx1_outputs
-////    {
-////        { 1200, {} }
-////    };
-////
-////    chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
-////    BOOST_REQUIRE(tx1.is_coinbase());
-////    const auto hash1 = tx1.hash();
-////
-////    // tx2: spends coinbase, tx1 as input, dummy output
-////    chain::input::list tx2_inputs
-////    {
-////        { { hash1, 0 }, {}, 0 }
-////    };
-////
-////    chain::output::list tx2_outputs
-////    {
-////        { 1200, {} }
-////    };
-////
-////    chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
-////    const auto hash2 = tx2.hash();
-////
-////    instance.store({tx1, tx2});
-////    instance.confirm(instance.get(tx1.hash()).link(), 23, 56, 0);
-////    instance.confirm(instance.get(tx2.hash()).link(), 123, 156, 0);
-////
-////    BOOST_REQUIRE_EQUAL(instance.get(hash1).transaction().outputs().front().metadata.confirmed_spend_height, 123);
-////    BOOST_REQUIRE(instance.get(hash1).transaction().outputs().front().metadata.spent(123, false));
-////
-////    // Setup end
-////
-////    const bool result = instance.unconfirm(instance.get(hash2).link());
-////    BOOST_REQUIRE(result);
-////
-////    const auto tx2_reloaded = instance.get(hash2);
-////
-////    BOOST_REQUIRE_EQUAL(tx2_reloaded.height(), machine::rule_fork::unverified);
-////    BOOST_REQUIRE_EQUAL(tx2_reloaded.median_time_past(), 0u);
-////    BOOST_REQUIRE_EQUAL(tx2_reloaded.position(), transaction_result::unconfirmed);
-////    BOOST_REQUIRE(!tx2_reloaded.candidate());
-////    BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spend);
-////
-////    const auto tx1_reloaded = instance.get(hash1);
-////
-////    BOOST_REQUIRE_EQUAL(tx1_reloaded.height(), 23);
-////    BOOST_REQUIRE_EQUAL(tx1_reloaded.median_time_past(), 56);
-////    BOOST_REQUIRE_EQUAL(tx1_reloaded.position(), 0);
-////    BOOST_REQUIRE(!tx1_reloaded.candidate());
-////    BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.candidate_spend);
-////
-////
-////    BOOST_REQUIRE_EQUAL(tx1_reloaded.transaction().outputs().front().metadata.confirmed_spend_height,
-////        machine::rule_fork::unverified);
-////    BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.spent(123, false));
-////}
+   // tx1: coinbase transaction
+   const chain::input::list tx1_inputs
+   {
+       { chain::point{ null_hash, chain::point::null_index }, {}, 0 }
+   };
+
+   chain::output::list tx1_outputs
+   {
+       { 1200, {} }
+   };
+
+   chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
+   BOOST_REQUIRE(tx1.is_coinbase());
+   const auto hash1 = tx1.hash();
+   instance.store(tx1, 1);
+
+   // tx2: spends coinbase, tx1 as input, dummy output
+   chain::input::list tx2_inputs
+   {
+       { { hash1, 0 }, {}, 0 }
+   };
+
+   chain::output::list tx2_outputs
+   {
+       { 1200, {} }
+   };
+
+   chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
+   instance.store(tx2, 1);
+
+   static const auto settings = system::settings(system::config::settings::mainnet);
+   chain::block block0 = settings.genesis_block;
+   block0.set_transactions({ tx1, tx2 });
+   
+   // Setup end
+
+   const bool result = instance.unconfirm(block0);
+   BOOST_REQUIRE(!result);
+}
+
+BOOST_AUTO_TEST_CASE(transaction_database__unconfirm__single_confirmed__success)
+{
+   uint32_t version = 2345u;
+   uint32_t locktime = 0xffffffff;
+
+   test::create(file_path);
+   transaction_database instance(file_path, 1000, 50, 0);
+   BOOST_REQUIRE(instance.create());
+
+   // tx1: coinbase transaction
+   const chain::input::list tx1_inputs
+   {
+       { chain::point{ null_hash, chain::point::null_index }, {}, 0 }
+   };
+
+   chain::output::list tx1_outputs
+   {
+       { 1200, {} }
+   };
+
+   chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
+   BOOST_REQUIRE(tx1.is_coinbase());
+   const auto hash1 = tx1.hash();
+   instance.store(tx1, 1);
+
+   // tx2: spends coinbase, tx1 as input, dummy output
+   chain::input::list tx2_inputs
+   {
+       { { hash1, 0 }, {}, 0 }
+   };
+
+   chain::output::list tx2_outputs
+   {
+       { 1200, {} }
+   };
+
+   chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
+   const auto hash2 = tx2.hash();
+   instance.store(tx2, 1);
+
+   instance.confirm(instance.get(tx1.hash()).link(), 23, 56, 1);
+   instance.confirm(instance.get(tx2.hash()).link(), 123, 156, 1);
+
+   BOOST_REQUIRE_EQUAL(instance.get(hash1).transaction().outputs().front().metadata.confirmed_spend_height, 123);
+   BOOST_REQUIRE(instance.get(hash1).transaction().outputs().front().metadata.spent(123, false));
+
+   static const auto settings = system::settings(system::config::settings::mainnet);
+   chain::block block0 = settings.genesis_block;
+   block0.set_transactions({tx2});
+   
+   // Setup end
+
+   const bool result = instance.unconfirm(block0);
+   BOOST_REQUIRE(result);
+
+   const auto tx2_reloaded = instance.get(hash2);
+
+   BOOST_REQUIRE_EQUAL(tx2_reloaded.height(), machine::rule_fork::unverified);
+   BOOST_REQUIRE_EQUAL(tx2_reloaded.median_time_past(), 0u);
+   BOOST_REQUIRE_EQUAL(tx2_reloaded.position(), transaction_result::unconfirmed);
+   BOOST_REQUIRE(!tx2_reloaded.candidate());
+   BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spend);
+
+   const auto tx1_reloaded = instance.get(hash1);
+
+   BOOST_REQUIRE_EQUAL(tx1_reloaded.height(), 23);
+   BOOST_REQUIRE_EQUAL(tx1_reloaded.median_time_past(), 56);
+   BOOST_REQUIRE_EQUAL(tx1_reloaded.position(), 1);
+   BOOST_REQUIRE(!tx1_reloaded.candidate());
+   BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.candidate_spend);
+
+
+   BOOST_REQUIRE_EQUAL(tx1_reloaded.transaction().outputs().front().metadata.confirmed_spend_height,
+       machine::rule_fork::unverified);
+   BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.spent(123, false));
+}
+
+BOOST_AUTO_TEST_CASE(transaction_database_with_cache__unconfirm__single_confirmed__success)
+{
+   uint32_t version = 2345u;
+   uint32_t locktime = 0xffffffff;
+
+   test::create(file_path);
+   transaction_database instance(file_path, 1000, 50, 100);
+   BOOST_REQUIRE(instance.create());
+
+   // tx1: coinbase transaction
+   const chain::input::list tx1_inputs
+   {
+       { chain::point{ null_hash, chain::point::null_index }, {}, 0 }
+   };
+
+   chain::output::list tx1_outputs
+   {
+       { 1200, {} }
+   };
+
+   chain::transaction tx1(version, locktime, tx1_inputs, tx1_outputs);
+   BOOST_REQUIRE(tx1.is_coinbase());
+   const auto hash1 = tx1.hash();
+   instance.store(tx1, 1);
+
+   // tx2: spends coinbase, tx1 as input, dummy output
+   chain::input::list tx2_inputs
+   {
+       { { hash1, 0 }, {}, 0 }
+   };
+
+   chain::output::list tx2_outputs
+   {
+       { 1200, {} }
+   };
+
+   chain::transaction tx2(version, locktime, tx2_inputs, tx2_outputs);
+   const auto hash2 = tx2.hash();
+   instance.store(tx2, 1);
+
+   instance.confirm(instance.get(tx1.hash()).link(), 23, 56, 1);
+   instance.confirm(instance.get(tx2.hash()).link(), 123, 156, 1);
+
+   BOOST_REQUIRE_EQUAL(instance.get(hash1).transaction().outputs().front().metadata.confirmed_spend_height, 123);
+   BOOST_REQUIRE(instance.get(hash1).transaction().outputs().front().metadata.spent(123, false));
+
+   static const auto settings = system::settings(system::config::settings::mainnet);
+   chain::block block0 = settings.genesis_block;
+   block0.set_transactions({tx2});
+
+   // Setup end
+
+   const bool result = instance.unconfirm(block0);
+   BOOST_REQUIRE(result);
+
+   const auto tx2_reloaded = instance.get(hash2);
+
+   BOOST_REQUIRE_EQUAL(tx2_reloaded.height(), machine::rule_fork::unverified);
+   BOOST_REQUIRE_EQUAL(tx2_reloaded.median_time_past(), 0u);
+   BOOST_REQUIRE_EQUAL(tx2_reloaded.position(), transaction_result::unconfirmed);
+   BOOST_REQUIRE(!tx2_reloaded.candidate());
+   BOOST_REQUIRE(!tx2_reloaded.transaction().outputs().front().metadata.candidate_spend);
+
+   const auto tx1_reloaded = instance.get(hash1);
+
+   BOOST_REQUIRE_EQUAL(tx1_reloaded.height(), 23);
+   BOOST_REQUIRE_EQUAL(tx1_reloaded.median_time_past(), 56);
+   BOOST_REQUIRE_EQUAL(tx1_reloaded.position(), 1);
+   BOOST_REQUIRE(!tx1_reloaded.candidate());
+   BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.candidate_spend);
+
+
+   BOOST_REQUIRE_EQUAL(tx1_reloaded.transaction().outputs().front().metadata.confirmed_spend_height,
+       machine::rule_fork::unverified);
+   BOOST_REQUIRE(!tx1_reloaded.transaction().outputs().front().metadata.spent(123, false));
+}
 
 
 // Queries - get_block_metadata
@@ -1114,37 +1140,43 @@ BOOST_AUTO_TEST_CASE(transaction_database__get_output__confirmed_at_height__conf
     BOOST_REQUIRE(!point.metadata.spent);
 }
 
-////BOOST_AUTO_TEST_CASE(transaction_database_with_cache__get_output__confirmed_at_height__confirmed)
-////{
-////    uint32_t version = 2345u;
-////    uint32_t locktime = 0xffffffff;
-////
-////    test::create(file_path);
-////    transaction_database instance(file_path, 1000, 50, 100);
-////    BOOST_REQUIRE(instance.create());
-////
-////    static const transaction tx1{ locktime, version, {}, { { 1200, {} } } };
-////
-////    // TODO: these two calls are now incompatible.
-////    // store(tx) is usable only for tx pool txs.
-////    // confirm(link) is usable only for optimizing confirmation of a block
-////    // populated from without use of unspent output caching.
-////    // The combination below mixes these two scenarios. As a result
-////    // point.metadata.confirmed is false because the output cache still retains
-////    // the unconfirmed output, since it cannot be confirmed within the cache.
-////    instance.store(tx1, 100);
-////    instance.confirm(instance.get(tx1.hash()).link(), 123, 156, 178);
-////
-////    output_point point{ tx1.hash(), 0 };
-////
-////    BOOST_REQUIRE(instance.get_output(point, 123, false));
-////    BOOST_REQUIRE(!point.metadata.coinbase);
-////    BOOST_REQUIRE(!point.metadata.candidate);
-////    BOOST_REQUIRE(point.metadata.confirmed);
-////    BOOST_REQUIRE_EQUAL(point.metadata.height, 123);
-////    BOOST_REQUIRE_EQUAL(point.metadata.median_time_past, 156);
-////    BOOST_REQUIRE(!point.metadata.spent);
-////}
+BOOST_AUTO_TEST_CASE(transaction_database_with_cache__get_output__confirmed_at_height__confirmed)
+{
+   uint32_t version = 2345u;
+   uint32_t locktime = 0xffffffff;
+
+   test::create(file_path);
+   transaction_database instance(file_path, 1000, 50, 100);
+   BOOST_REQUIRE(instance.create());
+
+   static const transaction tx1{ locktime, version, {}, { { 1201, {} } } };
+
+   // TODO: these two calls are now incompatible.
+   // store(tx) is usable only for tx pool txs.
+   // confirm(link) is usable only for optimizing confirmation of a block
+   // populated from without use of unspent output caching.
+   // The combination below mixes these two scenarios. As a result
+   // point.metadata.confirmed is false because the output cache still retains
+   // the unconfirmed output, since it cannot be confirmed within the cache.
+   instance.store({tx1});
+   static const auto settings = system::settings(system::config::settings::mainnet);
+   chain::block block0 = settings.genesis_block;
+
+   // get transaction so confirm has the link
+   block0.set_transactions({ instance.get(tx1.hash()).transaction() });
+
+   instance.confirm(block0, 123, 456);
+
+   output_point point{ tx1.hash(), 0 };
+
+   BOOST_REQUIRE(instance.get_output(point, 123, false));
+   BOOST_REQUIRE(!point.metadata.coinbase);
+   BOOST_REQUIRE(!point.metadata.candidate);
+   BOOST_REQUIRE(point.metadata.confirmed);
+   BOOST_REQUIRE_EQUAL(point.metadata.height, 123);
+   BOOST_REQUIRE_EQUAL(point.metadata.median_time_past, 456);
+   BOOST_REQUIRE(!point.metadata.spent);
+}
 
 BOOST_AUTO_TEST_CASE(transaction_database__get_output__unconfirmed_at_height__unconfirmed)
 {


### PR DESCRIPTION
@evoskuil Have updated the tests for confirm methods after switching to the confirm(block) method signature, but want to check something with you before asking for a full review/merge.

I am sharing this for an initial review. My question is about switching away from store(tx)/confirm(block) combination as you mentioned in a TODO comment.

I made a change here (https://github.com/evoskuil/libbitcoin-database/compare/master...kulpreet:bring_back_tests_for_confirm_and_optmize_changes?expand=1#diff-a1bb34106e9929d0927fe23c5a2785c1R1161) and want to check with you if store({tx})/get(hash)/confirm(block) combination will capture the use of the confirm(block) method.