### PR TITLE
Allow not_found sentinel to avoid assertion in hash_table::get

### DIFF
--- a/include/bitcoin/database/impl/hash_table.ipp
+++ b/include/bitcoin/database/impl/hash_table.ipp
@@ -95,7 +95,7 @@ hash_table<Manager, Index, Link, Key>::get(Link link) const
 {
     // Ensure requested position is within the file.
     // We avoid a runtime error here to optimize out the past_eof locks.
-    BITCOIN_ASSERT_MSG(link != not_found && !manager_.past_eof(link),
+    BITCOIN_ASSERT_MSG(!manager_.past_eof(link) || link == not_found,
         "Non-terminating link is past end of file.");
 
     // A not_found link value produces a terminator element.

--- a/test/primitives/hash_table.cpp
+++ b/test/primitives/hash_table.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(hash_table__slab__multiple_elements__expected)
     const_element2.read(reader2);
 }
 
-BOOST_AUTO_TEST_CASE(hash_table__record__unlink_first_stored__expected)
+BOOST_AUTO_TEST_CASE(hash_table__slab__unlink_first_stored__expected)
 {
     // Define hash table type.
     typedef test::tiny_hash key_type;
@@ -194,6 +194,68 @@ BOOST_AUTO_TEST_CASE(hash_table__record__unlink_first_stored__expected)
     BOOST_REQUIRE_EQUAL(const_element2.next(), slab_map::not_found);
     BOOST_REQUIRE(const_element2.match(key2));
     const_element2.read(reader2);
+}
+
+BOOST_AUTO_TEST_CASE(hash_table__get__record_range_of_links__success)
+{
+    // Define hash table type.
+    typedef test::tiny_hash key_type;
+    typedef uint32_t index_type;
+    typedef uint32_t link_type;
+    typedef hash_table<record_manager<link_type>, index_type, link_type, key_type> record_map;
+
+    test::storage file;
+    BOOST_REQUIRE(file.open());
+    record_map table(file, 2u, 4u);
+    BOOST_REQUIRE(table.create());
+
+    const key_type key1{ { 0xde, 0xad, 0xbe, 0xef } };
+    const auto writer1 = [](byte_serializer& serial)
+    {
+        serial.write_byte(110);
+        serial.write_byte(110);
+        serial.write_byte(4);
+        serial.write_byte(88);
+    };
+
+    // Allocate, create and store a new elements.
+    auto element = table.allocator();
+    const auto link1 = element.create(key1, writer1);
+    table.link(element);
+
+    BOOST_REQUIRE(table.get(link1));
+    BOOST_REQUIRE(!table.get(record_map::not_found));
+}
+
+BOOST_AUTO_TEST_CASE(hash_table__get__slab_range_of_links__success)
+{
+    // Define hash table type.
+    typedef test::tiny_hash key_type;
+    typedef uint32_t index_type;
+    typedef uint64_t link_type;
+    typedef hash_table<slab_manager<link_type>, index_type, link_type, key_type> slab_map;
+
+    test::storage file;
+    BOOST_REQUIRE(file.open());
+    slab_map table(file, 100u);
+    BOOST_REQUIRE(table.create());
+
+    const key_type key1{ { 0xde, 0xad, 0xbe, 0xef } };
+    const auto writer1 = [](byte_serializer& serial)
+    {
+        serial.write_byte(110);
+        serial.write_byte(110);
+        serial.write_byte(4);
+        serial.write_byte(88);
+    };
+
+    // Allocate, create and store a new elements.
+    auto element = table.allocator();
+    const auto link1 = element.create(key1, writer1);
+    table.link(element);
+
+    BOOST_REQUIRE(table.get(link1));
+    BOOST_REQUIRE(!table.get(slab_map::not_found));
 }
 
 BOOST_AUTO_TEST_CASE(hash_table__record__multiple_elements_32_bit__round_trips)


### PR DESCRIPTION
Small change to allow not_found sentinels to pass the assertion.

This is required because past_eof check will fail for not_found sentinel.

With this change, the assertion is fail only if link is greater than record count but is not not_found sentinel.
